### PR TITLE
remove unused navbar item

### DIFF
--- a/index.html
+++ b/index.html
@@ -300,15 +300,7 @@
         
         
           
-        
-
-        <li class="nav-item">
-          <a class="nav-link" href="/#posts" data-target="#posts">
-            
-            <span>Posts</span>
-            
-          </a>
-        </li>
+       
 
         
         


### PR DESCRIPTION
It seems to me that the "Posts" button on nav bar doesn't link to any part of the page, so you might want to remove them. At least, not showing them.